### PR TITLE
Sets variable typo error.

### DIFF
--- a/react-front-end/src/components/ExerciseListItem.js
+++ b/react-front-end/src/components/ExerciseListItem.js
@@ -42,7 +42,7 @@ export default function ExerciseListItem(props) {
       </div>
 
       <div className="mb-4 shadow border-1">
-        <Modal onClose={() => setModalShow(false)} show={show} id={id} set={sets} reps={reps} />
+        <Modal onClose={() => setModalShow(false)} show={show} id={id} sets={sets} reps={reps} />
       </div>
 
 


### PR DESCRIPTION
Fix typo error in ExerciseListItem `sets` variable. 